### PR TITLE
fix broken import on install

### DIFF
--- a/lshashpy3/lshash.py
+++ b/lshashpy3/lshash.py
@@ -7,41 +7,41 @@
 from __future__ import print_function, unicode_literals, division, absolute_import
 from builtins import int, round, str,  object  # noqa
 from future import standard_library
-standard_library.install_aliases()  # noqa: Counter, OrderedDict, 
+standard_library.install_aliases()  # noqa: Counter, OrderedDict,
 from past.builtins import basestring   # noqa:
- 
+
 import future        # noqa
 import builtins      # noqa
 import past          # noqa
 import six           # noqa
- 
+
 import os
 import json
 import numpy as np
- 
+
 try:
     from storage import storage  # py2
 except ImportError:
     from .storage import storage  # py3
- 
+
 try:
     from bitarray import bitarray
 except ImportError:
     bitarray = None
- 
- 
+
+
 try:
     xrange  # py2
 except NameError:
     xrange = range  # py3
- 
- 
+
+
 class LSHash(object):
     """ LSHash implments locality sensitive hashing using random projection for
     input vectors of dimension `input_dim`.
- 
+
     Attributes:
- 
+
     :param hash_size:
         The length of the resulting binary hash in integer. E.g., 32 means the
         resulting binary hash will be 32-bit long.
@@ -63,18 +63,18 @@ class LSHash(object):
     :param overwrite:
         (optional) Whether to overwrite the matrices file if it already exist
     """
- 
+
     def __init__(self, hash_size, input_dim, num_hashtables=1,
                  storage_config=None, matrices_filename=None, hashtable_filename=None, overwrite=False):
- 
+
         self.hash_size = hash_size
         self.input_dim = input_dim
         self.num_hashtables = num_hashtables
- 
+
         if storage_config is None:
             storage_config = {'dict': None}
         self.storage_config = storage_config
- 
+
         if matrices_filename and not matrices_filename.endswith('.npz'):
             raise ValueError("The specified file name must end with .npz")
         self.matrices_filename = matrices_filename
@@ -84,26 +84,26 @@ class LSHash(object):
         self.hashtable_filename = hashtable_filename
 
         self.overwrite = overwrite
- 
+
         self._init_uniform_planes()
         self._init_hashtables()
- 
+
     def _init_uniform_planes(self):
         """ Initialize uniform planes used to calculate the hashes
- 
+
         if file `self.matrices_filename` exist and `self.overwrite` is
         selected, save the uniform planes to the specified file.
- 
+
         if file `self.matrices_filename` exist and `self.overwrite` is not
         selected, load the matrix with `np.load`.
- 
+
         if file `self.matrices_filename` does not exist and regardless of
         `self.overwrite`, only set `self.uniform_planes`.
         """
- 
+
         if "uniform_planes" in self.__dict__:
             return
- 
+
         if self.matrices_filename:
             file_exist = os.path.isfile(self.matrices_filename)
             if file_exist and not self.overwrite:
@@ -127,7 +127,7 @@ class LSHash(object):
         else:
             self.uniform_planes = [self._generate_uniform_planes()
                                    for _ in xrange(self.num_hashtables)]
- 
+
     def _init_hashtables(self):
         """ Initialize the hash tables such that each record will be in the
         form of "[storage1, storage2, ...]" """
@@ -147,17 +147,17 @@ class LSHash(object):
         else:
             self.hash_tables = [storage(self.storage_config, i)
                                 for i in xrange(self.num_hashtables)]
- 
+
     def _generate_uniform_planes(self):
         """ Generate uniformly distributed hyperplanes and return it as a 2D
         numpy array.
         """
- 
+
         return np.random.randn(self.hash_size, self.input_dim)
- 
+
     def _hash(self, planes, input_point):
         """ Generates the binary hash for `input_point` and returns it.
- 
+
         :param planes:
             The planes are random uniform planes with a dimension of
             `hash_size` * `input_dim`.
@@ -165,7 +165,7 @@ class LSHash(object):
             A Python tuple or list object that contains only numbers.
             The dimension needs to be 1 * `input_dim`.
         """
- 
+
         try:
             input_point = np.array(input_point)  # for faster dot product
             projections = np.dot(planes, input_point)
@@ -179,7 +179,7 @@ class LSHash(object):
             raise
         else:
             return "".join(['1' if i > 0 else '0' for i in projections])
- 
+
     def _as_np_array(self, json_or_tuple):
         """ Takes either a JSON-serialized data structure or a tuple that has
         the original input points stored, and returns the original input point
@@ -198,11 +198,11 @@ class LSHash(object):
             # (point:tuple, extra_data). Otherwise (i.e., extra_data=None),
             # return the point stored as a tuple
             tuples = json_or_tuple
- 
+
         if isinstance(tuples[0], tuple):
             # in this case extra data exists
             return np.asarray(tuples[0])
- 
+
         elif isinstance(tuples, (tuple, list)):
             try:
                 return np.asarray(tuples)
@@ -211,15 +211,15 @@ class LSHash(object):
                 raise
         else:
             raise TypeError("query data is not supported")
- 
+
     def index(self, input_point, extra_data=None):
         """ Index a single input point by adding it to the selected storage.
- 
+
         If `extra_data` is provided, it will become the value of the dictionary
         {input_point: extra_data}, which in turn will become the value of the
         hash table. `extra_data` needs to be JSON serializable if in-memory
         dict is not used as storage.
- 
+
         :param input_point:
             A list, or tuple, or numpy ndarray object that contains numbers
             only. The dimension needs to be 1 * `input_dim`.
@@ -229,20 +229,23 @@ class LSHash(object):
             (optional) Needs to be a JSON-serializable object: list, dicts and
             basic types such as strings and integers.
         """
- 
+
         if isinstance(input_point, np.ndarray):
             input_point = input_point.tolist()
- 
+
         if extra_data:
             value = (tuple(input_point), extra_data)
         else:
             # LP: extra_data to None to keep output consistency
             value = (tuple(input_point), None)
- 
+
+        hashes = []
         for i, table in enumerate(self.hash_tables):
-            table.append_val(self._hash(self.uniform_planes[i], input_point),
-                             value)
-    
+            h = self._hash(self.uniform_planes[i], input_point)
+            table.append_val(h, value)
+            hashes.append(h)
+        return hashes
+
     def save(self):
         """
             Save save the uniform planes to the specified file.
@@ -259,7 +262,7 @@ class LSHash(object):
         """ Takes `query_point` which is either a tuple or a list of numbers,
         returns `num_results` of results as a list of tuples that are ranked
         based on the supplied metric function `distance_func`.
- 
+
         :param query_point:
             A list, or tuple, or numpy ndarray that only contains numbers.
             The dimension needs to be 1 * `input_dim`.
@@ -274,26 +277,26 @@ class LSHash(object):
             "centred_euclidean", "cosine", "l1norm"). By default "euclidean"
             will used.
         """
- 
+
         candidates = set()
         if not distance_func:
             distance_func = "euclidean"
- 
+
         if distance_func == "hamming":
             if not bitarray:
                 raise ImportError(" Bitarray is required for hamming distance")
- 
+
             for i, table in enumerate(self.hash_tables):
                 binary_hash = self._hash(self.uniform_planes[i], query_point)
                 for key in table.keys():
                     distance = LSHash.hamming_dist(key, binary_hash)
                     if distance < 2:
                         candidates.update(table.get_list(key))
- 
+
             d_func = LSHash.euclidean_dist_square
- 
+
         else:
- 
+
             if distance_func == "euclidean":
                 d_func = LSHash.euclidean_dist_square
             elif distance_func == "true_euclidean":
@@ -306,47 +309,47 @@ class LSHash(object):
                 d_func = LSHash.l1norm_dist
             else:
                 raise ValueError("The distance function name is invalid.")
- 
+
             for i, table in enumerate(self.hash_tables):
                 binary_hash = self._hash(self.uniform_planes[i], query_point)
                 candidates.update(table.get_list(binary_hash))
- 
+
         # rank candidates by distance function
         candidates = [(ix, d_func(query_point, self._as_np_array(ix)))
                       for ix in candidates]
         candidates = sorted(candidates, key=lambda x: x[1])
- 
+
         return candidates[:num_results] if num_results else candidates
- 
+
     ### distance functions
- 
+
     @staticmethod
     def hamming_dist(bitarray1, bitarray2):
         xor_result = bitarray(bitarray1) ^ bitarray(bitarray2)
         return xor_result.count()
- 
+
     @staticmethod
     def euclidean_dist(x, y):
         """ This is a hot function, hence some optimizations are made. """
         diff = np.array(x) - y
         return np.sqrt(np.dot(diff, diff))
- 
+
     @staticmethod
     def euclidean_dist_square(x, y):
         """ This is a hot function, hence some optimizations are made. """
         diff = np.array(x) - y
         return np.dot(diff, diff)
- 
+
     @staticmethod
     def euclidean_dist_centred(x, y):
         """ This is a hot function, hence some optimizations are made. """
         diff = np.mean(x) - np.mean(y)
         return np.dot(diff, diff)
- 
+
     @staticmethod
     def l1norm_dist(x, y):
         return sum(abs(x - y))
- 
+
     @staticmethod
     def cosine_dist(x, y):
         return 1 - float(np.dot(x, y)) / ((np.dot(x, x) * np.dot(y, y)) ** 0.5)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import lshashpy3
-
 try:
     from setuptools import setup
 except ImportError:
@@ -15,11 +13,11 @@ with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
 with open(path.join(this_directory, 'CHANGES.rst'), encoding='utf-8') as f:
     changes = f.read()
 
-required = ['numpy', 'bitarray']
+required = ['future', 'six', 'numpy', 'bitarray']
 
 setup(
     name='lshashpy3',
-    version=lshashpy3.__version__,
+    version='0.0.8',
     packages=['lshashpy3'],
     author='Kay Zhu',
     author_email='me@kayzhu.com',
@@ -30,7 +28,7 @@ setup(
     long_description=readme + '\n\n' + changes,
     long_description_content_type='text/x-rst',
     license='MIT License',
-    requires=required,
+    install_requires=required,
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Installing from scratch causes errors due to the `import lshashpy3` on line 1 of `setup.py` which has dependencies that could be absent.

I hard-coded the version string since this was the only use of the import and added the missing dependencies (`future`, `six`) to the setup.