### PR TITLE
Standard imports for Python 3.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ LSHash
 ======
 
 :Version: 0.0.8
-:Python: 3.7.7
+:Python: 3.11.5
 
 A fast Python implementation of locality sensitive hashing with persistance
 support.

--- a/lshashpy3/lshash.py
+++ b/lshashpy3/lshash.py
@@ -6,13 +6,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals, division, absolute_import
 from builtins import int, round, str,  object  # noqa
-from future import standard_library
-standard_library.install_aliases()  # noqa: Counter, OrderedDict,
-from past.builtins import basestring   # noqa:
 
-import future        # noqa
+try:
+  basestring
+except NameError:
+  basestring = str
+
+#import future        # noqa
 import builtins      # noqa
-import past          # noqa
+#import past          # noqa
 import six           # noqa
 
 import os
@@ -28,7 +30,6 @@ try:
     from bitarray import bitarray
 except ImportError:
     bitarray = None
-
 
 try:
     xrange  # py2


### PR DESCRIPTION
With this changes is working in Python 3.11:

```
% python3
Python 3.11.5 (main, Aug 24 2023, 15:09:45) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
% python3 example.py 
query (euclidean): [(((2, 3, 4, 5, 6, 7, 8, 9), None), 11)]
query (hamming): [(((2, 3, 4, 5, 6, 7, 8, 9), None), 11)]
(10, 12, 99, 1, 5, 31, 2, 3) vec1 6
(10, 11, 94, 1, 4, 31, 2, 3) vec2 33
query (euclidean): [(((10, 12, 99, 1, 5, 31, 2, 3), 'vec1'), 6), (((10, 11, 94, 1, 4, 31, 2, 3), 'vec2'), 33)]
query from disk (euclidean): []
```