### PR TITLE
Proper check for empty extra_data

### DIFF
--- a/lshashpy3/lshash.py
+++ b/lshashpy3/lshash.py
@@ -234,7 +234,7 @@ class LSHash(object):
         if isinstance(input_point, np.ndarray):
             input_point = input_point.tolist()
 
-        if extra_data:
+        if extra_data is not None:
             value = (tuple(input_point), extra_data)
         else:
             # LP: extra_data to None to keep output consistency


### PR DESCRIPTION
Better way to store extra data in the hashes.

Previously, the check for `extra_data` would fail if I attempted to store values that would be evaluated to false in the if statement, e.g. `False` or `0`. If I am using `extra_data=False`, I would like to get `False` instead of `None` later.

I changed the if statement to check for `None` the right way. I was having some annoying bugs because some of extra data that I was trying to store would be wrongly evaluated to `False`, and then replaced with `None`.